### PR TITLE
[Feat 10] 세션 로직 수정 및 order 관련 post 요청 API 개발

### DIFF
--- a/src/controllers/session.controller.js
+++ b/src/controllers/session.controller.js
@@ -25,7 +25,7 @@ exports.openBySlugWithCode = async (req, res, next) => {
   try {
     const { slug, code } = req.body || {};
     const data = await sessionService.openBySlugWithCode({ slug, code });
-    res.status(StatusCodes.OK).json({
+    return res.status(StatusCodes.OK).json({
       success: true,
       message: 'session opened (global code verified)',
       data,

--- a/src/controllers/session.controller.js
+++ b/src/controllers/session.controller.js
@@ -1,6 +1,7 @@
 const { StatusCodes } = require('http-status-codes');
 const AppError = require('../errors/AppError');
 const sessionService = require('../services/session.service');
+const { DiningTable } = require('../models');
 
 exports.openSessionByToken = async (req, res, next) => {
   try {
@@ -14,6 +15,20 @@ exports.openSessionByToken = async (req, res, next) => {
       success: true,
       message: 'session opened',
       data: out,
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.openBySlugWithCode = async (req, res, next) => {
+  try {
+    const { slug, code } = req.body || {};
+    const data = await sessionService.openBySlugWithCode({ slug, code });
+    res.status(StatusCodes.OK).json({
+      success: true,
+      message: 'session opened (global code verified)',
+      data,
     });
   } catch (err) {
     next(err);

--- a/src/models/DiningTable.js
+++ b/src/models/DiningTable.js
@@ -1,3 +1,4 @@
+// src/models/DiningTable.js
 const { DataTypes } = require('sequelize');
 const sequelize = require('../../config/database');
 const hashids = require('../utils/hashids');
@@ -10,17 +11,15 @@ const DiningTable = sequelize.define(
       autoIncrement: true,
       primaryKey: true,
     },
-    // 사람이 보는 테이블명 (예: "A-10")
     label: {
       type: DataTypes.STRING(20),
       allowNull: false,
       comment: '표시용 테이블명',
     },
-    // QR/URL용 내부 식별자 (id 기반 hashids) — 인쇄 QR에는 이 값을 넣음
     slug: {
       type: DataTypes.STRING(64),
       allowNull: true,
-      unique: true,
+      // ❌ unique: true  <-- 인라인 유니크 제거
       comment: 'URL-safe 슬러그',
     },
     is_active: {
@@ -28,10 +27,23 @@ const DiningTable = sequelize.define(
       allowNull: false,
       defaultValue: true,
     },
+    current_session_id: {
+      type: DataTypes.BIGINT.UNSIGNED,
+      allowNull: true,
+      comment: '현재 테이블의 활성 세션 (이전 토큰 차단용)',
+    },
   },
   {
     tableName: 'dining_tables',
-    indexes: [{ unique: true, fields: ['label'] }], // 매장 단일 기준; 다점포면 (venue_id, label)로 변경
+    indexes: [
+      // ✅ 인덱스는 '이름을 지정'해서 단일화
+      { name: 'uq_dining_tables_label', unique: true, fields: ['label'] },
+      { name: 'uq_dining_tables_slug', unique: true, fields: ['slug'] },
+      {
+        name: 'idx_dining_tables_current_session_id',
+        fields: ['current_session_id'],
+      },
+    ],
   }
 );
 
@@ -39,10 +51,9 @@ DiningTable.addHook('beforeValidate', (t) => {
   if (t.label) t.label = String(t.label).trim();
 });
 
-// id가 생성된 후 slug를 id→hash로 채움 (label 변경과 무관)
 DiningTable.addHook('afterCreate', async (t, options) => {
   if (!t.slug) {
-    t.slug = hashids.encode(t.id); // 다점포면 encode([venue_id, t.id]) 등으로 확장
+    t.slug = hashids.encode(t.id);
     await t.save({ transaction: options.transaction });
   }
 });

--- a/src/models/Order.js
+++ b/src/models/Order.js
@@ -36,6 +36,13 @@ const Order = sequelize.define(
       comment: '주문 유형(매장/포장)',
     },
 
+    // + 세션 내 순번
+    order_seq: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: false,
+      comment: '세션 내 n번째 주문(1부터 시작)',
+    },
+
     status: {
       type: DataTypes.ENUM(
         'PENDING',
@@ -69,10 +76,15 @@ const Order = sequelize.define(
   {
     tableName: 'orders',
     indexes: [
-      { name: 'idx_orders_session', fields: ['order_session_id'] },
-      { name: 'idx_orders_table', fields: ['table_id'] },
-      { name: 'idx_orders_type', fields: ['order_type'] },
+      { name: 'idx_orders_order_session_id', fields: ['order_session_id'] },
+      { name: 'idx_orders_table_id', fields: ['table_id'] },
       { name: 'idx_orders_status', fields: ['status'] },
+      // 세션 내 순번 유일 보장
+      {
+        name: 'uq_orders_session_seq',
+        unique: true,
+        fields: ['order_session_id', 'order_seq'],
+      },
     ],
   }
 );

--- a/src/models/Order.js
+++ b/src/models/Order.js
@@ -1,3 +1,4 @@
+// src/models/Order.js
 const { DataTypes } = require('sequelize');
 const sequelize = require('../../config/database');
 
@@ -10,14 +11,12 @@ const Order = sequelize.define(
       primaryKey: true,
     },
 
-    // 세션 스냅샷 (필수)
     order_session_id: {
       type: DataTypes.BIGINT.UNSIGNED,
       allowNull: false,
       comment: '주문이 생성된 OrderSession',
     },
 
-    // 테이블 스냅샷 (기존 운영 편의 때문에 유지, 세션과 동일하게 세팅)
     table_id: {
       type: DataTypes.BIGINT.UNSIGNED,
       allowNull: false,
@@ -29,16 +28,18 @@ const Order = sequelize.define(
       allowNull: true,
       comment: '입금자명',
     },
+
     order_type: {
       type: DataTypes.ENUM('DINE_IN', 'TAKEOUT'),
       allowNull: false,
       defaultValue: 'DINE_IN',
       comment: '주문 유형(매장/포장)',
     },
+
     status: {
       type: DataTypes.ENUM(
-        'PENDING', // 입금 대기
-        'CONFIRMED', // 입금 확인 후 주문 수락
+        'PENDING',
+        'CONFIRMED',
         'IN_PROGRESS',
         'SERVED',
         'CANCELED'
@@ -63,16 +64,15 @@ const Order = sequelize.define(
       defaultValue: 0,
       comment: '주문총액',
     },
-
     discount_reason: { type: DataTypes.STRING(64), allowNull: true }, // ex) TAKEOUT_10_OFF
   },
   {
     tableName: 'orders',
     indexes: [
-      { fields: ['order_session_id'] },
-      { fields: ['table_id'] },
-      { fields: ['order_type'] },
-      { fields: ['status'] },
+      { name: 'idx_orders_session', fields: ['order_session_id'] },
+      { name: 'idx_orders_table', fields: ['table_id'] },
+      { name: 'idx_orders_type', fields: ['order_type'] },
+      { name: 'idx_orders_status', fields: ['status'] },
     ],
   }
 );

--- a/src/models/Order.js
+++ b/src/models/Order.js
@@ -80,11 +80,11 @@ const Order = sequelize.define(
       { name: 'idx_orders_table_id', fields: ['table_id'] },
       { name: 'idx_orders_status', fields: ['status'] },
       // 세션 내 순번 유일 보장
-      {
-        name: 'uq_orders_session_seq',
-        unique: true,
-        fields: ['order_session_id', 'order_seq'],
-      },
+      // {
+      //   name: 'uq_orders_session_seq',
+      //   unique: true,
+      //   fields: ['order_session_id', 'order_seq'],
+      // },
     ],
   }
 );

--- a/src/models/OrderProduct.js
+++ b/src/models/OrderProduct.js
@@ -1,3 +1,4 @@
+// src/models/OrderProduct.js
 const { DataTypes } = require('sequelize');
 const sequelize = require('../../config/database');
 
@@ -9,24 +10,21 @@ const OrderProduct = sequelize.define(
       autoIncrement: true,
       primaryKey: true,
     },
+
     order_id: {
       type: DataTypes.BIGINT.UNSIGNED,
       allowNull: false,
-      references: {
-        model: 'orders', // 참조 테이블명
-        key: 'id',
-      },
+      references: { model: 'orders', key: 'id' },
       onDelete: 'CASCADE',
     },
+
     product_id: {
       type: DataTypes.BIGINT.UNSIGNED,
       allowNull: false,
-      references: {
-        model: 'products', // 참조 테이블명
-        key: 'id',
-      },
+      references: { model: 'products', key: 'id' },
       onDelete: 'CASCADE',
     },
+
     quantity: {
       type: DataTypes.INTEGER.UNSIGNED,
       allowNull: false,
@@ -39,10 +37,9 @@ const OrderProduct = sequelize.define(
   {
     tableName: 'order_products',
     indexes: [
-      { fields: ['order_id'] },
-      { fields: ['product_id'] },
-      // 중복 라인 방지하려면 다음을 활성화
-      // { unique: true, fields: ['order_id', 'product_id'] },
+      { name: 'idx_order_products_order', fields: ['order_id'] },
+      { name: 'idx_order_products_product', fields: ['product_id'] },
+      // { name: 'uq_order_products_order_product', unique: true, fields: ['order_id', 'product_id'] },
     ],
     hooks: {
       beforeValidate(item) {

--- a/src/models/OrderSession.js
+++ b/src/models/OrderSession.js
@@ -22,6 +22,11 @@ const OrderSession = sequelize.define(
       defaultValue: 'OPEN',
     },
     visit_started_at: { type: DataTypes.DATE, allowNull: true },
+    order_count: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: false,
+      defaultValue: 0,
+    },
     last_active_at: { type: DataTypes.DATE, allowNull: true },
     active_flag: { type: DataTypes.TINYINT, allowNull: false, defaultValue: 1 },
     closed_reason: { type: DataTypes.STRING(64), allowNull: true },

--- a/src/models/OrderSession.js
+++ b/src/models/OrderSession.js
@@ -1,3 +1,4 @@
+// src/models/OrderSession.js
 const { DataTypes } = require('sequelize');
 const sequelize = require('../../config/database');
 
@@ -10,32 +11,42 @@ const OrderSession = sequelize.define(
       primaryKey: true,
     },
     table_id: { type: DataTypes.BIGINT.UNSIGNED, allowNull: false },
-    token_id: { type: DataTypes.BIGINT.UNSIGNED, allowNull: true }, // 회전 토큰과 연결(선택)
-    session_token: {
-      type: DataTypes.STRING(128),
-      allowNull: false,
-      unique: true,
-    },
+    token_id: { type: DataTypes.BIGINT.UNSIGNED, allowNull: true },
+
+    // 🔴 여기! unique: true 삭제
+    session_token: { type: DataTypes.STRING(128), allowNull: false },
+
     status: {
       type: DataTypes.ENUM('OPEN', 'CLOSED', 'EXPIRED'),
       allowNull: false,
       defaultValue: 'OPEN',
     },
-
-    // 방문 시작 시각(세션 생성 시 기록)
     visit_started_at: { type: DataTypes.DATE, allowNull: true },
-
     last_active_at: { type: DataTypes.DATE, allowNull: true },
-    // 동시 스캔 방지: OPEN=1, CLOSED/EXPIRED=0 → (table_id, active_flag) UNIQUE
     active_flag: { type: DataTypes.TINYINT, allowNull: false, defaultValue: 1 },
     closed_reason: { type: DataTypes.STRING(64), allowNull: true },
   },
   {
     tableName: 'order_sessions',
     indexes: [
-      { unique: true, fields: ['session_token'] },
-      // { unique: true, fields: ['table_id', 'active_flag'] }, // 테이블당 OPEN 1개 보장
-      { fields: ['table_id', 'status'] },
+      // ✅ 이름 있는 유니크 인덱스만 유지
+      {
+        name: 'uq_order_sessions_session_token',
+        unique: true,
+        fields: ['session_token'],
+      },
+
+      // 운영 정책에 따라 유지
+      {
+        name: 'order_sessions_table_id_status',
+        fields: ['table_id', 'status'],
+      },
+
+      // token_id 단일 인덱스가 필요하면 명시
+      { name: 'idx_order_sessions_token_id', fields: ['token_id'] },
+
+      // 테이블 당 OPEN 1개 강제하고 싶으면 아래 주석 해제(데이터 정리 필요)
+      // { name: 'uq_order_sessions_table_active', unique: true, fields: ['table_id', 'active_flag'] },
     ],
   }
 );

--- a/src/models/OrderSession.js
+++ b/src/models/OrderSession.js
@@ -21,6 +21,10 @@ const OrderSession = sequelize.define(
       allowNull: false,
       defaultValue: 'OPEN',
     },
+
+    // 방문 시작 시각(세션 생성 시 기록)
+    visit_started_at: { type: DataTypes.DATE, allowNull: true },
+
     last_active_at: { type: DataTypes.DATE, allowNull: true },
     // 동시 스캔 방지: OPEN=1, CLOSED/EXPIRED=0 → (table_id, active_flag) UNIQUE
     active_flag: { type: DataTypes.TINYINT, allowNull: false, defaultValue: 1 },

--- a/src/models/Product.js
+++ b/src/models/Product.js
@@ -12,7 +12,7 @@ const Product = sequelize.define(
     name: {
       type: DataTypes.STRING(100),
       allowNull: false,
-      unique: true,
+
       comment: '메뉴명',
     },
     price: {
@@ -47,7 +47,10 @@ const Product = sequelize.define(
   },
   {
     tableName: 'products',
-    indexes: [{ fields: ['is_active'] }, { fields: ['name'] }],
+    indexes: [
+      { name: 'uq_products_name', unique: true, fields: ['name'] },
+      { name: 'idx_products_is_active', fields: ['is_active'] },
+    ],
   }
 );
 

--- a/src/models/TableQrToken.js
+++ b/src/models/TableQrToken.js
@@ -1,3 +1,4 @@
+// src/models/TableQrToken.js
 const { DataTypes } = require('sequelize');
 const sequelize = require('../../config/database');
 
@@ -9,21 +10,29 @@ const TableQrToken = sequelize.define(
       autoIncrement: true,
       primaryKey: true,
     },
+
     table_id: { type: DataTypes.BIGINT.UNSIGNED, allowNull: false },
-    token: { type: DataTypes.STRING(128), allowNull: false, unique: true },
+
+    // ❌ 컬럼에 unique 금지: named index로만 관리
+    token: { type: DataTypes.STRING(128), allowNull: false },
+
     status: {
       type: DataTypes.ENUM('ACTIVE', 'REVOKED', 'EXPIRED'),
       allowNull: false,
       defaultValue: 'ACTIVE',
     },
+
     expires_at: { type: DataTypes.DATE, allowNull: true },
     revoked_at: { type: DataTypes.DATE, allowNull: true },
   },
   {
     tableName: 'table_qr_tokens',
     indexes: [
-      { unique: true, fields: ['token'] },
-      { fields: ['table_id', 'status'] },
+      { name: 'uq_table_qr_tokens_token', unique: true, fields: ['token'] },
+      {
+        name: 'idx_table_qr_tokens_table_status',
+        fields: ['table_id', 'status'],
+      },
     ],
   }
 );

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -39,6 +39,11 @@ OrderProduct.belongsTo(Product, {
 });
 Product.hasMany(OrderProduct, { foreignKey: 'product_id' });
 
+DiningTable.belongsTo(OrderSession, {
+  as: 'currentSession',
+  foreignKey: 'current_session_id',
+});
+
 // 세션/토큰 ←→ 테이블
 OrderSession.belongsTo(DiningTable, {
   foreignKey: { name: 'table_id', allowNull: false },

--- a/src/routes/admin.route.js
+++ b/src/routes/admin.route.js
@@ -5,7 +5,7 @@ const adminController = require('../controllers/admin.controller');
 
 router.post('/tables/ensure', adminController.ensureTableByLabel);
 
-router.post('/tables/:id/qr/update', adminController.rotateQrToken);
+// router.post('/tables/:id/qr/update', adminController.rotateQrToken); deptrecated
 
 router.post('/login', adminController.login);
 

--- a/src/routes/session.route.js
+++ b/src/routes/session.route.js
@@ -2,7 +2,9 @@ const express = require('express');
 const router = express.Router();
 const sessionController = require('../controllers/session.controller');
 
-router.post('/resolve', sessionController.openSessionByToken);
+// router.post('/resolve', sessionController.openSessionByToken); deprecated
+
+router.post('/open-by-slug', sessionController.openBySlugWithCode);
 
 router.post('/:id/close', sessionController.closeSessionById);
 

--- a/src/services/order.service.js
+++ b/src/services/order.service.js
@@ -1,7 +1,36 @@
 const { StatusCodes } = require('http-status-codes');
-const { Op, literal } = require('sequelize');
 const AppError = require('../errors/AppError');
-const { sequelize, Order, OrderProduct, Product } = require('../models');
+const {
+  sequelize,
+  Order,
+  OrderProduct,
+  Product,
+  OrderSession,
+} = require('../models');
+
+async function withDeadlockRetry(
+  fn,
+  { retries = 4, minDelayMs = 15, maxDelayMs = 60 } = {}
+) {
+  let attempt = 0;
+  // 지수 + 랜덤 백오프
+  while (true) {
+    try {
+      return await fn();
+    } catch (err) {
+      const code = err?.parent?.code || err?.original?.code;
+      if (code !== 'ER_LOCK_DEADLOCK' || attempt >= retries) throw err;
+      const jitter =
+        Math.floor(Math.random() * (maxDelayMs - minDelayMs + 1)) + minDelayMs;
+      const sleep = Math.min(
+        maxDelayMs,
+        (minDelayMs + jitter) * (1 << attempt)
+      );
+      await new Promise((r) => setTimeout(r, sleep));
+      attempt++;
+    }
+  }
+}
 
 exports.createOrder = async ({ session, order_type, payer_name, items }) => {
   if (!session)
@@ -9,76 +38,134 @@ exports.createOrder = async ({ session, order_type, payer_name, items }) => {
   if (!Array.isArray(items) || items.length === 0)
     throw new AppError('items required', StatusCodes.BAD_REQUEST);
 
-  return await sequelize.transaction(async (t) => {
-    let subtotal = 0;
-    const lines = [];
+  return await withDeadlockRetry(async () => {
+    return await sequelize.transaction(async (t) => {
+      // 1) 세션 OPEN 확인 + order_count 원자 증가(단일 UPDATE)
+      const [updateRes] = await sequelize.query(
+        `
+        UPDATE order_sessions
+           SET order_count = order_count + 1,
+               visit_started_at = IFNULL(visit_started_at, NOW()),
+               last_active_at   = NOW()
+         WHERE id = ?
+           AND status = 'OPEN'
+        `,
+        { replacements: [session.id], transaction: t }
+      );
 
-    for (const it of items) {
-      const p = await Product.findOne({
-        where: { id: it.product_id, is_active: true },
-        transaction: t,
-      });
-      if (!p)
+      // MySQL 드라이버별로 반환 형태가 달라 affectedRows 노멀라이즈
+      const affected =
+        typeof updateRes?.affectedRows === 'number'
+          ? updateRes.affectedRows
+          : typeof updateRes === 'number'
+            ? updateRes
+            : 0;
+
+      if (!affected) {
         throw new AppError(
-          `invalid product: ${it.product_id}`,
-          StatusCodes.BAD_REQUEST
+          'Invalid or closed session',
+          StatusCodes.UNPROCESSABLE_ENTITY
         );
+      }
 
-      const qty = Number(it.quantity || 0);
-      if (qty < 1) throw new AppError('quantity >= 1', StatusCodes.BAD_REQUEST);
+      // 2) 증가된 최신 order_count/visit_started_at/ table_id 읽기 (FOR UPDATE)
+      const [[sesRow]] = await sequelize.query(
+        `
+        SELECT id, table_id, order_count, visit_started_at
+          FROM order_sessions
+         WHERE id = ?
+         FOR UPDATE
+        `,
+        { replacements: [session.id], transaction: t }
+      );
 
-      const unit = Number(p.price);
-      const line = Number((unit * qty).toFixed(2));
-      subtotal = Number((subtotal + line).toFixed(2));
-      lines.push({
-        product_id: p.id,
-        quantity: qty,
-        unit_price: unit,
-        line_total: line,
-      });
-    }
+      if (!sesRow) {
+        throw new AppError(
+          'Session not found',
+          StatusCodes.UNPROCESSABLE_ENTITY
+        );
+      }
 
-    // TAKEOUT 10% 할인
-    let discount = 0;
-    let reason = null;
-    if (order_type === 'TAKEOUT') {
-      discount = Number((subtotal * 0.1).toFixed(2));
-      reason = 'TAKEOUT_10_OFF';
-    }
-    const total = Number((subtotal - discount).toFixed(2));
+      const nextSeq = Number(sesRow.order_count);
+      const tableId = Number(sesRow.table_id);
+      const firstOrderAt = sesRow.visit_started_at
+        ? new Date(sesRow.visit_started_at)
+        : new Date();
 
-    // 세션/테이블 스냅샷 저장 (설계상 필수)
-    const order = await Order.create(
-      {
-        order_session_id: session.id,
-        table_id: session.table_id,
+      // 3) 금액 계산
+      let subtotal = 0;
+      const lines = [];
+      for (const it of items) {
+        const p = await Product.findOne({
+          where: { id: it.product_id, is_active: true },
+          transaction: t,
+        });
+        if (!p)
+          throw new AppError(
+            `invalid product: ${it.product_id}`,
+            StatusCodes.BAD_REQUEST
+          );
 
-        payer_name: payer_name || null,
-        order_type: order_type || 'DINE_IN',
-        status: 'PENDING',
-        subtotal_amount: subtotal,
-        discount_amount: discount,
-        total_amount: total,
-        discount_reason: reason,
-      },
-      { transaction: t }
-    );
+        const qty = Number(it.quantity || 0);
+        if (qty < 1)
+          throw new AppError('quantity >= 1', StatusCodes.BAD_REQUEST);
 
-    for (const L of lines) {
-      await OrderProduct.create(
-        { order_id: order.id, ...L },
+        const unit = Number(p.price);
+        const line = Number((unit * qty).toFixed(2));
+        subtotal = Number((subtotal + line).toFixed(2));
+        lines.push({
+          product_id: p.id,
+          quantity: qty,
+          unit_price: unit,
+          line_total: line,
+        });
+      }
+
+      // 4) 할인
+      let discount = 0,
+        reason = null;
+      if (order_type === 'TAKEOUT') {
+        discount = Number((subtotal * 0.1).toFixed(2));
+        reason = 'TAKEOUT_10_OFF';
+      }
+      const total = Number((subtotal - discount).toFixed(2));
+
+      // 5) 주문 생성 — ★ order_seq = nextSeq 반드시 세팅
+      const order = await Order.create(
+        {
+          order_session_id: session.id,
+          table_id: tableId,
+          order_seq: nextSeq,
+          payer_name: payer_name || null,
+          order_type: order_type || 'DINE_IN',
+          status: 'PENDING',
+          subtotal_amount: subtotal,
+          discount_amount: discount,
+          total_amount: total,
+          discount_reason: reason,
+        },
         { transaction: t }
       );
-    }
 
-    return {
-      order_id: order.id,
-      order_type: order.order_type,
-      status: order.status,
-      subtotal_amount: order.subtotal_amount,
-      discount_amount: order.discount_amount,
-      total_amount: order.total_amount,
-    };
+      // 6) 라인 아이템
+      for (const L of lines) {
+        await OrderProduct.create(
+          { order_id: order.id, ...L },
+          { transaction: t }
+        );
+      }
+
+      return {
+        order_id: order.id,
+        order_seq: order.order_seq,
+        order_type: order.order_type,
+        status: order.status,
+        subtotal_amount: order.subtotal_amount,
+        discount_amount: order.discount_amount,
+        total_amount: order.total_amount,
+        first_order_at: firstOrderAt,
+      };
+    });
   });
 };
 

--- a/src/services/session.service.js
+++ b/src/services/session.service.js
@@ -2,6 +2,7 @@ const crypto = require('crypto');
 const AppError = require('../errors/AppError');
 const { StatusCodes } = require('http-status-codes');
 const { makeRandomToken } = require('../utils/token');
+const { withRetry } = require('../utils/retry');
 const {
   sequelize,
   DiningTable,
@@ -84,91 +85,59 @@ exports.openSessionByToken = async (code) => {
   });
 };
 
-async function withDeadlockRetry(fn, { attempts = 3, delayMs = 60 } = {}) {
-  let lastErr;
-  for (let i = 0; i < attempts; i++) {
-    try {
-      return await fn();
-    } catch (err) {
-      // MySQL deadlock
-      if (
-        err?.original?.code === 'ER_LOCK_DEADLOCK' ||
-        err?.parent?.code === 'ER_LOCK_DEADLOCK'
-      ) {
-        lastErr = err;
-        // 지수 백오프
-        await new Promise((r) => setTimeout(r, delayMs * Math.pow(2, i)));
-        continue;
-      }
-      throw err;
-    }
-  }
-  throw lastErr;
-}
-
 exports.openBySlugWithCode = async ({ slug, code }) => {
-  if (!slug || !code) {
+  if (!slug || !code)
     throw new AppError('slug and code required', StatusCodes.BAD_REQUEST);
-  }
-
   const expected = String(process.env.SESSION_OPEN_CODE || '');
-  if (!expected) {
+  if (!expected)
     throw new AppError(
       'SESSION_OPEN_CODE not configured',
       StatusCodes.INTERNAL_SERVER_ERROR
     );
-  }
-  if (String(code) !== expected) {
+  if (String(code) !== expected)
     throw new AppError('invalid code', StatusCodes.UNPROCESSABLE_ENTITY);
-  }
 
-  return await withDeadlockRetry(async () => {
+  return await withRetry(async () => {
     return await sequelize.transaction(async (t) => {
-      // 1) 테이블 잠금
       const table = await DiningTable.findOne({
         where: { slug, is_active: true },
         transaction: t,
         lock: t.LOCK.UPDATE,
       });
-      if (!table) {
+      if (!table)
         throw new AppError(
           'table not found or inactive',
           StatusCodes.NOT_FOUND
         );
-      }
 
-      // 2) 이 테이블의 OPEN 세션 id들을 "잠그고" 고정된 순서로 수집
       const openRows = await OrderSession.findAll({
         attributes: ['id'],
         where: { table_id: table.id, status: 'OPEN' },
         order: [['id', 'ASC']],
         transaction: t,
-        lock: t.LOCK.UPDATE, // SELECT ... FOR UPDATE
+        lock: t.LOCK.UPDATE,
       });
-
       const openIds = openRows.map((r) => r.id);
-      if (openIds.length > 0) {
-        // 3) 모아둔 id들만 일괄 UPDATE
+      if (openIds.length) {
         await OrderSession.update(
           { status: 'EXPIRED', active_flag: 0 },
           { where: { id: openIds }, transaction: t }
         );
       }
 
-      // 4) 새 세션 생성
       const now = new Date();
       const ses = await OrderSession.create(
         {
           table_id: table.id,
           session_token: makeRandomToken(),
           status: 'OPEN',
+          visit_started_at: now,
           last_active_at: now,
           active_flag: 1,
         },
         { transaction: t }
       );
 
-      // 5) 현재 세션 포인터 갱신
       table.current_session_id = ses.id;
       await table.save({ transaction: t });
 
@@ -177,7 +146,7 @@ exports.openBySlugWithCode = async ({ slug, code }) => {
         session_token: ses.session_token,
         table: { id: table.id, label: table.label, slug: table.slug },
         abs_ttl_min: Number(process.env.SESSION_ABS_TTL_MIN || 120),
-        idle_ttl_min: Number(process.env.SESSION_IDLE_TTL_MIN || 120),
+        idle_ttl_min: Number(process.env.SESSION_IDLE_TTL_MIN || 30),
       };
     });
   });

--- a/src/services/session.service.js
+++ b/src/services/session.service.js
@@ -162,7 +162,6 @@ exports.openBySlugWithCode = async ({ slug, code }) => {
           table_id: table.id,
           session_token: makeRandomToken(),
           status: 'OPEN',
-          visit_started_at: now,
           last_active_at: now,
           active_flag: 1,
         },
@@ -178,7 +177,7 @@ exports.openBySlugWithCode = async ({ slug, code }) => {
         session_token: ses.session_token,
         table: { id: table.id, label: table.label, slug: table.slug },
         abs_ttl_min: Number(process.env.SESSION_ABS_TTL_MIN || 120),
-        idle_ttl_min: Number(process.env.SESSION_IDLE_TTL_MIN || 30),
+        idle_ttl_min: Number(process.env.SESSION_IDLE_TTL_MIN || 120),
       };
     });
   });

--- a/src/utils/retry.js
+++ b/src/utils/retry.js
@@ -1,0 +1,34 @@
+// 지수 백오프 + 지터. 기본은 데드락(1213), 락타임아웃(1205)에서만 재시도.
+function defaultShouldRetry(err) {
+  const code = err?.parent?.code || err?.original?.code;
+  return code === 'ER_LOCK_DEADLOCK' || code === 'ER_LOCK_WAIT_TIMEOUT';
+}
+
+async function withRetry(
+  fn,
+  {
+    retries = 4,
+    minDelayMs = 20,
+    maxDelayMs = 200,
+    shouldRetry = defaultShouldRetry,
+  } = {}
+) {
+  let attempt = 0;
+  while (true) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (!shouldRetry(err) || attempt >= retries) throw err;
+
+      // 지수 + 지터
+      const base = Math.min(maxDelayMs, minDelayMs * Math.pow(2, attempt));
+      const jitter = Math.floor(Math.random() * base);
+      const sleep = Math.min(maxDelayMs, base + jitter);
+      await new Promise((r) => setTimeout(r, sleep));
+
+      attempt += 1;
+    }
+  }
+}
+
+module.exports = { withRetry, defaultShouldRetry };

--- a/src/utils/token.js
+++ b/src/utils/token.js
@@ -1,0 +1,12 @@
+// utils/token.js
+const crypto = require('crypto');
+
+/**
+ * 랜덤 세션 토큰 생성
+ * @param {number} len - 바이트 길이 (기본 32 → hex 64자리)
+ */
+function makeRandomToken(len = 32) {
+  return crypto.randomBytes(len).toString('hex');
+}
+
+module.exports = { makeRandomToken };

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -9,7 +9,11 @@ servers:
 paths:
   /admin/tables/ensure:
     post:
-      summary: Ensure table by label (create if missing) and return slug URL
+      summary: 테이블 QR 코드용 암호화된 식별자 생성 API
+      description: >
+        관리자가 테이블 라벨(label)을 지정하면, 해당 라벨에 해당하는 테이블을 찾아 존재하지 않으면 새로 생성하고,  
+        이미 존재하면 기존 테이블을 반환한다.  
+        반환되는 데이터에는 **QR 코드 URL에 붙일 수 있는 암호화된 slug 값**이 포함된다.
       tags: [Admin]
       requestBody:
         required: true
@@ -32,129 +36,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EnsureTableResponse'
-              examples:
-                created:
-                  value:
-                    success: true
-                    message: created successfully
-                    data:
-                      table:
-                        { id: 1, label: A-10, slug: ezygbX, is_active: true }
-                      qr: { slugUrl: 'http://localhost:8080/t/ezygbX' }
-                      created: true
         '200':
           description: OK (table already existed)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/EnsureTableResponse'
-              examples:
-                existed:
-                  value:
-                    success: true
-                    message: request retrieved successfully
-                    data:
-                      table:
-                        { id: 1, label: A-10, slug: ezygbX, is_active: true }
-                      qr: { slugUrl: 'http://localhost:8080/t/ezygbX' }
-                      created: false
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/ServerError'
 
-  /admin/tables/{id}/qr/update:
-    post:
-      summary: Rotate QR token for a table (revoke old, issue new)
-      tags: [Admin]
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema: { type: integer, minimum: 1 }
-          description: Table ID
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RotateTokenResponse'
-              examples:
-                ok:
-                  value:
-                    success: true
-                    message: QR token rotated successfully
-                    data:
-                      table:
-                        id: 1
-                        label: A-10
-                        slug: WKSo9VVdn8v
-                        is_active: true
-                      qr:
-                        tokenUrl: 'http://localhost:8080/t?code=f07e...c2'
-                        slugUrl: 'http://localhost:8080/t/WKSo9VVdn8v'
-                      token: 'f07e...c2'
-                      expires_at: null
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
-
-  /sessions/resolve:
-    post:
-      summary: Open a session by rotating token (QR code)
-      tags: [Public]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required: [code]
-              properties:
-                code:
-                  type: string
-                  description: Active QR token from the scanned URL (?code=...)
-                  example: f07e0f4d5b3b4f8eac...
-      responses:
-        '200':
-          description: Session opened
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SessionOpenResponse'
-              examples:
-                ok:
-                  value:
-                    success: true
-                    message: session opened
-                    data:
-                      session_token: '4e6d...ab'
-                      session_id: 321
-                      table: { id: 1, label: A-10, slug: q8L2Xa }
-                      abs_ttl_min: 120
-                      idle_ttl_min: 30
-        '422':
-          description: Invalid or expired token
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                invalid:
-                  value: { success: false, message: 'invalid or revoked token' }
-                expired:
-                  value: { success: false, message: 'token expired' }
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
-
   /sessions/{id}/close:
     post:
-      summary: Force-close a session by ID
-      tags: [Public]
+      summary: 관리자 권한으로 세션 강제 종료 API
+      description: >
+        특정 테이블에서 열린 세션이 정상적으로 종료되지 않았거나 **세션 상태가 꼬였을 때**,  
+        관리자가 세션 ID를 지정하여 해당 세션을 강제로 종료할 수 있다.  
+        정상적으로 종료되면 세션 상태는 닫힘으로 업데이트된다.
+      tags: [Admin]
       parameters:
         - in: path
           name: id
@@ -167,34 +67,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SimpleOkResponse'
-              examples:
-                ok:
-                  value:
-                    { success: true, message: 'session closed successfully' }
         '404':
           description: Session not found
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                notfound:
-                  value: { success: false, message: 'session not found' }
         '409':
           description: Session not open (already closed/expired)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                conflict:
-                  value: { success: false, message: 'session not open' }
         '500':
           $ref: '#/components/responses/ServerError'
 
   /admin/login:
     post:
-      summary: Admin PIN login (issue JWT)
+      summary: 관리자 PIN 로그인 API
+      description: >
+        관리자가 사전에 설정된 **PIN 번호**를 입력하여 로그인하면,  
+        인증 성공 시 JWT 토큰이 발급된다.  
+        이 토큰은 이후 관리자 전용 API 호출 시 `Authorization: Bearer <JWT>` 헤더에 포함하여 사용할 수 있다.
       tags: [Admin]
       requestBody:
         required: true
@@ -202,9 +96,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/AdminLoginRequest'
-            examples:
-              sample:
-                value: { pin: '1234' }
       responses:
         '200':
           description: Login successful (JWT issued)
@@ -212,38 +103,79 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AdminLoginResponse'
-              examples:
-                ok:
-                  value:
-                    success: true
-                    message: 'Login successful'
-                    token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...'
         '400':
           description: Missing PIN
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                missing:
-                  value: { success: false, message: 'PIN is required' }
         '401':
           description: Invalid PIN
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                invalid:
-                  value: { success: false, message: 'Invalid PIN' }
         '500':
           $ref: '#/components/responses/ServerError'
 
+  /sessions/open-by-slug:
+    post:
+      summary: 테이블 slug 값으로 세션 열기
+      description: >
+        관리자가 발급한 글로벌 코드(`SESSION_OPEN_CODE`)와 테이블 slug로 세션을 강제로 여는 API로,
+        기존 열려 있는 세션이 있으면 모두 만료(EXPIRED) 처리 후 새로운 세션을 생성한다.
+      tags: [Public]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [slug, code]
+              properties:
+                slug:
+                  type: string
+                  example: ezygbX
+                code:
+                  type: string
+                  example: sC2mj4Kgp
+      responses:
+        '200':
+          description: Session opened successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionOpenResponse'
+        '400':
+          description: Missing slug/code
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Config missing
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Invalid code
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Table not found or inactive
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ServerError'
 
   /orders:
     post:
       summary: Create an order (session required)
-      description: Create a new order with line items. Uses session token from QR flow. TAKEOUT applies 10% discount.
       tags: [Public]
       parameters:
         - in: header
@@ -262,23 +194,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/OrderCreateRequest'
-            examples:
-              dine_in:
-                summary: DINE_IN example
-                value:
-                  order_type: DINE_IN
-                  payer_name: 임승우
-                  items:
-                    - { product_id: 1, quantity: 2 }
-                    - { product_id: 3, quantity: 1 }
-              takeout:
-                summary: TAKEOUT example (10% off)
-                value:
-                  order_type: TAKEOUT
-                  payer_name: 임승우
-                  items:
-                    - { product_id: 2, quantity: 1 }
-                    - { product_id: 5, quantity: 3 }
       responses:
         '201':
           description: Created
@@ -286,85 +201,44 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OrderCreateResponse'
-              examples:
-                ok:
-                  value:
-                    success: true
-                    message: order created
-                    data:
-                      order_id: 123
-                      order_type: DINE_IN
-                      status: PENDING
-                      subtotal_amount: 22000.00
-                      discount_amount: 0.00
-                      total_amount: 22000.00
         '400':
-          description: Bad Request (invalid items, quantity < 1, etc.)
+          description: Bad Request
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                invalidItems:
-                  value: { success: false, message: 'items required' }
         '401':
-          description: Unauthorized (missing/invalid session)
+          description: Unauthorized
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                noSession:
-                  value: { success: false, message: 'No session token' }
         '409':
-          description: Conflict (out of stock, etc.)
+          description: Conflict
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                conflict:
-                  value: { success: false, message: 'out of stock' }
         '500':
           $ref: '#/components/responses/ServerError'
 
-    /orders/{id}/status:
+  /orders/{id}/status:
     patch:
-      summary: Update order status by action (admin only)
-      description: >
-        액션 기반 상태 전이.\n
-        - PENDING --confirm--> CONFIRMED (재고 차감)\n
-        - CONFIRMED --start--> IN_PROGRESS\n
-        - IN_PROGRESS --serve--> SERVED\n
-        - PENDING/CONFIRMED --cancel--> CANCELED (확정 후 취소 시 재고 복구)
-      tags: [Admin, Orders]
+      summary: 관리자가 주문의 상태를 업데이트할 때 사용된다.
+      tags: [Admin]
       security:
-        - bearerAuth: []  # Authorization: Bearer <JWT>
+        - bearerAuth: []
       parameters:
         - in: path
           name: id
           required: true
           schema: { type: integer, minimum: 1 }
-          description: Order ID
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/OrderStatusUpdateRequest'
-            examples:
-              confirm:
-                summary: Confirm (PENDING -> CONFIRMED)
-                value: { action: confirm, reason: '입금 확인' }
-              start:
-                summary: Start (CONFIRMED -> IN_PROGRESS)
-                value: { action: start }
-              serve:
-                summary: Serve (IN_PROGRESS -> SERVED)
-                value: { action: serve }
-              cancel_from_pending:
-                summary: Cancel from PENDING
-                value: { action: cancel, reason: '고객 취소' }
       responses:
         '200':
           description: Updated
@@ -372,54 +246,44 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OrderStatusUpdateResponse'
-              examples:
-                ok:
-                  value:
-                    success: true
-                    message: Status updated successfully
-                    data: { order_id: 123, prev: PENDING, next: CONFIRMED }
         '400':
-          description: Bad Request (invalid order id / action missing)
+          description: Bad Request
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                invalidAction:
-                  value: { success: false, message: "action required (one of: confirm, start, serve, cancel)" }
         '401':
-          description: Unauthorized (missing/invalid admin JWT)
+          description: Unauthorized
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                noToken:
-                  value: { success: false, message: 'Invalid or expired token' }
         '404':
           description: Order not found
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                notfound:
-                  value: { success: false, message: 'order not found' }
         '409':
-          description: Conflict (invalid transition / out of stock on confirm)
+          description: Conflict
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                invalidTransition:
-                  value: { success: false, message: 'invalid transition: PENDING -> (serve)' }
-                outOfStock:
-                  value: { success: false, message: 'out of stock' }
         '500':
           $ref: '#/components/responses/ServerError'
 
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+    sessionAuth:
+      type: apiKey
+      in: header
+      name: Authorization
+
   schemas:
     Table:
       type: object
@@ -428,6 +292,7 @@ components:
         label: { type: string, example: A-10 }
         slug: { type: string, example: ezygbX }
         is_active: { type: boolean, example: true }
+
     EnsureTableData:
       type: object
       properties:
@@ -438,68 +303,34 @@ components:
           properties:
             slugUrl: { type: string, example: 'http://localhost:8080/t/ezygbX' }
         created: { type: boolean, example: true }
+
     EnsureTableResponse:
       type: object
       properties:
-        success: { type: boolean, example: true }
-        message: { type: string, example: created successfully }
+        success: { type: boolean }
+        message: { type: string }
         data:
           $ref: '#/components/schemas/EnsureTableData'
-
-    RotateTokenData:
-      type: object
-      properties:
-        table:
-          $ref: '#/components/schemas/Table'
-        qr:
-          type: object
-          properties:
-            tokenUrl:
-              {
-                type: string,
-                example: 'http://localhost:8080/t?code=f07e...c2',
-              }
-            slugUrl:
-              { type: string, example: 'http://localhost:8080/t/WKSo9VVdn8v' }
-        token: { type: string, example: f07e...c2 }
-        expires_at:
-          type: string
-          format: date-time
-          nullable: true
-          example: null
-    RotateTokenResponse:
-      type: object
-      properties:
-        success: { type: boolean, example: true }
-        message: { type: string, example: QR token rotated successfully }
-        data:
-          $ref: '#/components/schemas/RotateTokenData'
 
     AdminLoginRequest:
       type: object
       required: [pin]
       properties:
-        pin:
-          type: string
-          example: '1234'
+        pin: { type: string, example: '2025' }
 
     AdminLoginResponse:
       type: object
       properties:
-        success: { type: boolean, example: true }
-        message: { type: string, example: Login successful }
-        token:
-          type: string
-          description: 'JWT. Use as Authorization: Bearer <token>'
-          example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...'
+        success: { type: boolean }
+        message: { type: string }
+        token: { type: string }
 
-    
     OrderItemInput:
       type: object
       required: [product_id, quantity]
       properties:
-        product_id: { type: integer, example: 1, minimum: 1 }
-        quantity:   { type: integer, example: 2, minimum: 1 }
+        product_id: { type: integer, example: 1 }
+        quantity: { type: integer, example: 2 }
 
     OrderCreateRequest:
       type: object
@@ -508,32 +339,28 @@ components:
         order_type:
           type: string
           enum: [DINE_IN, TAKEOUT]
-          default: DINE_IN
         payer_name:
           type: string
-          nullable: true
-          example: 임승우
         items:
           type: array
-          minItems: 1
           items:
             $ref: '#/components/schemas/OrderItemInput'
 
     OrderCreateData:
       type: object
       properties:
-        order_id:        { type: integer, example: 123 }
-        order_type:      { type: string, example: DINE_IN }
-        status:          { type: string, example: PENDING }
-        subtotal_amount: { type: number, format: float, example: 22000.00 }
-        discount_amount: { type: number, format: float, example: 0.00 }
-        total_amount:    { type: number, format: float, example: 22000.00 }
+        order_id: { type: integer }
+        order_type: { type: string }
+        status: { type: string }
+        subtotal_amount: { type: number }
+        discount_amount: { type: number }
+        total_amount: { type: number }
 
     OrderCreateResponse:
       type: object
       properties:
-        success: { type: boolean, example: true }
-        message: { type: string, example: order created }
+        success: { type: boolean }
+        message: { type: string }
         data:
           $ref: '#/components/schemas/OrderCreateData'
 
@@ -541,54 +368,50 @@ components:
       type: object
       required: [action]
       properties:
-        action:
-          type: string
-          enum: [confirm, start, serve, cancel]
-        reason:
-          type: string
-          nullable: true
-          example: '입금 확인'
+        action: { type: string, enum: [confirm, start, serve, cancel] }
+        reason: { type: string }
 
     OrderStatusUpdateResponse:
       type: object
       properties:
-        success: { type: boolean, example: true }
-        message: { type: string, example: Status updated successfully }
+        success: { type: boolean }
+        message: { type: string }
         data:
           type: object
           properties:
-            order_id: { type: integer, example: 123 }
-            prev:     { type: string, example: PENDING }
-            next:     { type: string, example: CONFIRMED }
+            order_id: { type: integer }
+            prev: { type: string }
+            next: { type: string }
 
     SessionOpenData:
       type: object
       properties:
-        session_token: { type: string, example: '4e6d...ab' }
-        session_id: { type: integer, example: 321 }
+        session_token: { type: string }
+        session_id: { type: integer }
         table:
           $ref: '#/components/schemas/Table'
-        abs_ttl_min: { type: integer, example: 120 }
-        idle_ttl_min: { type: integer, example: 30 }
+        abs_ttl_min: { type: integer }
+        idle_ttl_min: { type: integer }
+
     SessionOpenResponse:
       type: object
       properties:
-        success: { type: boolean, example: true }
-        message: { type: string, example: session opened }
+        success: { type: boolean }
+        message: { type: string }
         data:
           $ref: '#/components/schemas/SessionOpenData'
 
     SimpleOkResponse:
       type: object
       properties:
-        success: { type: boolean, example: true }
-        message: { type: string, example: session closed successfully }
+        success: { type: boolean }
+        message: { type: string }
 
     ErrorResponse:
       type: object
       properties:
         success: { type: boolean, example: false }
-        message: { type: string, example: Bad Request }
+        message: { type: string }
 
   responses:
     BadRequest:
@@ -597,18 +420,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
-          examples:
-            missingLabel:
-              value: { success: false, message: 'label (string) is required' }
     NotFound:
       description: Not Found
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
-          examples:
-            notfound:
-              value: { success: false, message: 'table not found or inactive' }
     ServerError:
       description: Internal Server Error
       content:


### PR DESCRIPTION
`/sessions/open-by-slug`: 관리자가 발급한 글로벌 코드(`SESSION_OPEN_CODE`)와 테이블 slug로 세션을 강제로 여는 API로, 기존 열려 있는 세션이 있으면 모두 만료(EXPIRED) 처리 후 새로운 세션을 생성한다.

---

`/orders/{id}/status`: 관리자가 주문의 상태를 업데이트할 때 사용된다.

---

`/orders`: 사용자가 주문 요청 시에 사용된다.